### PR TITLE
Bump toolbelt to v3.4.2

### DIFF
--- a/base/releases.yml
+++ b/base/releases.yml
@@ -6,6 +6,6 @@ releases:
   sha1:    722b6c40e36b7f71517bfa1aec0062e8daca1f9f
 
 - name:    toolbelt
-  version: 3.4.1
-  url:     https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v3.4.1/toolbelt-3.4.1.tgz
-  sha1:    59dcc5a33ee5f806b9a75ccf831344a6479c5b0e
+  version: 3.4.2
+  url:     https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v3.4.2/toolbelt-3.4.2.tgz
+  sha1:    2b4debac0ce6115f8b265ac21b196dda206e93ed

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -5,3 +5,6 @@
 - This kit now supports`stemcell_os` and `stemcell_version`
   parameters, which is a de facto standard for handling version
   pinning and stemcell selection.
+
+- Bumped `toolbelt` release version to 3.4.2
+


### PR DESCRIPTION
Updated toolbelt release to https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/tag/v3.4.2