### PR TITLE
Add DNS search domain support to the wizard

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -89,7 +89,7 @@ params:
 
 - `openvpn` - Provides an OpenVPN server, giving users access to
   the internal infrastructure without requiring an SSH session.
-  Intead, users will be issued an X.509 identity certificate which
+  Instead, users will be issued an X.509 identity certificate which
   will grant them access to connect to the VPN and access internal
   resources from their connecting device (usually their own
   workstation).
@@ -106,12 +106,12 @@ params:
     These must be specified in dotted-quad notation, i.e.:
     `192.168.0.0 255.255.255.0` (a /24).
 
-  - `dns_servers` - A list of DNS servers that will be advertised
+  - `vpn_dns_servers` - A list of DNS servers that will be advertised
     to connecting VPN clients.  Most VPN client software will set
     these as the canonical system name resolvers while the VPN is
     connected.
 
-  - `dns_search_domains` - A list of DNS search domains that will
+  - `vpn_dns_search_domains` - A list of DNS search domains that will
     be advertised to connecting VPN clients.  This frees up
     clients from having to type the entire FQDN for name
     resolution to function properly.

--- a/hooks/new
+++ b/hooks/new
@@ -12,6 +12,10 @@ if [[ $openvpn == 'true' ]]; then
   prompt_for vpn_dns_servers multi-line \
     'What DNS servers should OpenVPN advertise to connecting clients?' \
     --min 1
+
+  prompt_for vpn_dns_search_domains multi-line \
+    'What DNS search domains should OpenVPN advertise to connecting clients?' \
+    --min 1
 fi
 
 trap "rm -f $GENESIS_ROOT/.$GENESIS_ENVIRONMENT.yml" INT QUIT TERM EXIT
@@ -36,6 +40,10 @@ if [[ $openvpn == 'true' ]]; then
   echo "  vpn_dns_servers:"
   for dns in ${vpn_dns_servers[@]}; do
     echo "    - $dns"
+  done
+  echo "  vpn_dns_search_domains:"
+  for domain in ${vpn_dns_search_domains[@]}; do
+    echo "    - $domain"
   done
   echo
 fi


### PR DESCRIPTION
This PR fixes #12 

Previously if an operator requested OpenVPN support for the Jumpbox, the generated configuration would fail to deploy because it was missing the `vpn_dns_search_domains` parameter. This commit fixes that, and updates the documentation a bit.