### PR TITLE
Update jumpbox release to 4.7.4

### DIFF
--- a/manifests/jumpbox.yml
+++ b/manifests/jumpbox.yml
@@ -53,9 +53,9 @@ stemcells:
 
 releases:
 - name:    jumpbox
-  version: 4.7.3
-  url:     https://github.com/cloudfoundry-community/jumpbox-boshrelease/releases/download/v4.7.3/jumpbox-4.7.3.tgz
-  sha1:    a5718c380d14ae9e7b16d8179bb4b8efab59fba8
+  version: 4.7.4
+  url:     https://github.com/cloudfoundry-community/jumpbox-boshrelease/releases/download/v4.7.4/jumpbox-4.7.4.tgz
+  sha1:    3370769f6a0799855f889e6b6bdc42dae5a08931
 - name:    toolbelt
   version: 3.5.0
   url:     https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v3.5.0/toolbelt-3.5.0.tgz


### PR DESCRIPTION
This upgrades `genesis` from 2.7.5 to 2.7.6 needed for some of the newer
kits where the minimum `genesis` version is 2.7.6