### PR TITLE
Add wireguard VPN feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.log
 ops/*.yml
+manifests/peers.dynamic.yml

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -181,6 +181,47 @@ params:
 
   - `vpn_extra_client_configs` - List of additional OpenVPN client configuration options.
 
+- `wireguard` - Provides a WireGuard VPN endpoint on the jumpbox.
+  Unlike OpenVPN, WireGuard uses base64 Curve25519 keypairs instead
+  of X.509 certificates; peers (clients) are managed through
+  vault-backed addons and take effect on redeploy via `wg syncconf`,
+  which never interrupts established sessions.
+
+  Requires an `ubuntu-noble` stemcell (the wireguard BOSH release
+  depends on the in-kernel WireGuard module).
+
+  The `openvpn` and `wireguard` features may be enabled together;
+  the kit merges their iptables FORWARD/POSTROUTING rules when both
+  are active.
+
+  Activating this feature also activates the following parameters:
+
+  - `wireguard_cidr` - Tunnel network for clients, in CIDR notation.
+    Defaults to `10.20.31.0/24` (distinct from OpenVPN's default
+    `172.31.255.0/24` so both VPNs can coexist).
+
+  - `wireguard_server_address` - The server's in-tunnel address CIDR.
+    Defaults to `10.20.31.1/24`; keep it the `.1` of `wireguard_cidr`.
+
+  - `wireguard_interface` - Interface name.  Defaults to `wg0`.
+
+  - `wireguard_port` - UDP listen port.  Defaults to `51820`.  This
+    port must be reachable from clients (security group or firewall
+    rule — the kit opens nothing for you).
+
+  - `wireguard_endpoint` - Public host or host:port clients dial.
+    Falls back to the jumpbox VM's IP when unset.
+
+  - `wireguard_routed_networks` - Networks advertised to clients
+    (AllowedIPs in generated client configs), in CIDR notation.
+
+  - `wireguard_dns` - DNS servers written into generated client
+    configs.
+
+  - `wireguard_iptables_forward` - iptables FORWARD rules required
+    for WireGuard traffic to flow.  Automatically generated via
+    `genesis new`, but can be modified or added to.
+
 # User Management
 
 The Jumpbox Genesis Kit provides flexible options for managing users.
@@ -443,6 +484,39 @@ If the `openvpn` feature is enabled, the following addons are also available:
   given user.
   ```
   genesis do my-env -- generate-vpn-config username
+  ```
+
+## WireGuard Addons
+
+If the `wireguard` feature is enabled, the following addons are also available:
+
+- `add-peer <name> [extra-allowed-cidr ...]` (alias `ap`) - Register a
+  new WireGuard peer: generates a keypair and preshared key, allocates
+  the lowest free tunnel address, and stores everything in vault.  The
+  peer becomes active on the next deploy.
+  ```
+  genesis do my-env -- add-peer laptop
+  ```
+
+- `remove-peer <name>` (alias `rp`) - Revoke a peer.  Its registry
+  entry moves to the `revoked/` archive and the next deploy drops it
+  from the interface.
+  ```
+  genesis do my-env -- remove-peer laptop
+  ```
+
+- `list-peers` (alias `lp`) - List registered peers with their tunnel
+  addresses and allowed IPs.
+  ```
+  genesis do my-env -- list-peers
+  ```
+
+- `generate-wg-config [-q] <name>` (alias `gw`) - Emit a wg-quick
+  client configuration for a registered peer.  With `-q`, also render
+  it as a terminal QR code (requires `qrencode`) for direct import
+  into mobile clients.
+  ```
+  genesis do my-env -- generate-wg-config laptop
   ```
 
 For detailed information on addon commands, see the [Addon Commands documentation](docs/addons.md).

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -296,23 +296,23 @@ managing users and their SSH keys from various sources.
 
 ```bash
 # Add a user's SSH keys from GitHub (default source)
-genesis do my-env -- users add username
+genesis my-env do users add username
 
 # Add a user's SSH keys from GitLab
-genesis do my-env -- users add gitlab/username
+genesis my-env do users add gitlab/username
 
 # Add keys from a local public key file
-genesis do my-env -- users add /path/to/username.pub
+genesis my-env do users add /path/to/username.pub
 
 # Add keys from a directory containing public key files
-genesis do my-env -- users add /path/to/keys/directory/
+genesis my-env do users add /path/to/keys/directory/
 ```
 
 ### Removing Users
 
 ```bash
 # Remove a user
-genesis do my-env -- users remove username
+genesis my-env do users remove username
 ```
 
 ### Key Source Options
@@ -413,29 +413,29 @@ For detailed STACKIT configuration, see the [STACKIT Configuration Guide](docs/i
 
 - `inventory` - Run the inventory errand against the deployment.
   ```
-  genesis do my-env -- inventory
+  genesis my-env do inventory
   ```
 
 - `ssh` - SSH into the jumpbox interactively.
   ```
-  genesis do my-env -- ssh
+  genesis my-env do ssh
   ```
 
 - `who` - SSH into the jumpbox and determine who is logged in.
   ```
-  genesis do my-env -- who
+  genesis my-env do who
   ```
 
 - `users` - Manage user accounts and SSH keys from various sources.
   ```
   # Add users
-  genesis do my-env -- users add github/username
-  genesis do my-env -- users add gitlab/username
-  genesis do my-env -- users add /path/to/key.pub
-  genesis do my-env -- users add /path/to/keys/dir/
+  genesis my-env do users add github/username
+  genesis my-env do users add gitlab/username
+  genesis my-env do users add /path/to/key.pub
+  genesis my-env do users add /path/to/keys/dir/
   
   # Remove users
-  genesis do my-env -- users remove username
+  genesis my-env do users remove username
   ```
 
 ## OpenVPN Addons
@@ -445,30 +445,30 @@ If the `openvpn` feature is enabled, the following addons are also available:
 - `certs` - List all the X.509 VPN certificates for the users registered on 
   this jumpbox.
   ```
-  genesis do my-env -- certs
+  genesis my-env do certs
   ```
 
 - `issue-cert <user>` - Issue an X.509 certificate to a user, so that they
   can connect and authenticate to the VPN.
   ```
-  genesis do my-env -- issue-cert username
+  genesis my-env do issue-cert username
   ```
 
 - `revoke-cert <user>` - Revoke an issued X.509 VPN certificate.
   ```
-  genesis do my-env -- revoke-cert username
+  genesis my-env do revoke-cert username
   ```
 
 - `renew-cert <user>` - Renew the lifetime of an existing X.509 VPN
   certificate, without changing the key that the user has.
   ```
-  genesis do my-env -- renew-cert username
+  genesis my-env do renew-cert username
   ```
 
 - `renew-all-certs` - Renew the lifetime of all existing X.509 VPN
   certificates, without changing the keys.
   ```
-  genesis do my-env -- renew-all-certs
+  genesis my-env do renew-all-certs
   ```
 
 - `reissue-cert <user>` - Reissue an X.509 VPN certificate, and
@@ -476,14 +476,14 @@ If the `openvpn` feature is enabled, the following addons are also available:
   example, a key has been lost or compromised. The old
   certificate will be revoked.
   ```
-  genesis do my-env -- reissue-cert username
+  genesis my-env do reissue-cert username
   ```
   
 - `generate-vpn-config <user>` - Generate a client certificate
   (if missing) and a new (or updated) openvpn config file for a 
   given user.
   ```
-  genesis do my-env -- generate-vpn-config username
+  genesis my-env do generate-vpn-config username
   ```
 
 ## WireGuard Addons
@@ -495,20 +495,20 @@ If the `wireguard` feature is enabled, the following addons are also available:
   the lowest free tunnel address, and stores everything in vault.  The
   peer becomes active on the next deploy.
   ```
-  genesis do my-env -- add-peer laptop
+  genesis my-env do add-peer laptop
   ```
 
 - `remove-peer <name>` (alias `rp`) - Revoke a peer.  Its registry
   entry moves to the `revoked/` archive and the next deploy drops it
   from the interface.
   ```
-  genesis do my-env -- remove-peer laptop
+  genesis my-env do remove-peer laptop
   ```
 
 - `list-peers` (alias `lp`) - List registered peers with their tunnel
   addresses and allowed IPs.
   ```
-  genesis do my-env -- list-peers
+  genesis my-env do list-peers
   ```
 
 - `generate-wg-config [-q] <name>` (alias `gw`) - Emit a wg-quick
@@ -516,7 +516,7 @@ If the `wireguard` feature is enabled, the following addons are also available:
   it as a terminal QR code (requires `qrencode`) for direct import
   into mobile clients.
   ```
-  genesis do my-env -- generate-wg-config laptop
+  genesis my-env do generate-wg-config laptop
   ```
 
 For detailed information on addon commands, see the [Addon Commands documentation](docs/addons.md).
@@ -575,7 +575,7 @@ If your jumpbox deployment is locked and cannot be updated:
 
 1. Check if any users are currently logged in:
    ```
-   genesis do my-env -- who
+   genesis my-env do who
    ```
 
 2. If necessary, notify users and wait for them to log out before

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The kit now features robust user management capabilities:
 - Import SSH keys from local files or directories
 - Dynamically manage users without modifying deployment manifests
 
-Example: `genesis do my-env -- users add github/username`
+Example: `genesis my-env do users add github/username`
 
 See the [User Management documentation](docs/user-management.md) for details.
 

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -28,6 +28,14 @@ meta:
       type:       github-release
       repository: cloudfoundry-community/openvpn-bosh-release
 
+    - name:       wireguard
+      type:       github-release
+      repository: cloudfoundry-community/wireguard-boshrelease
+
+    - name:       bpm
+      type:       bosh-io-release
+      repository: cloudfoundry/bpm-release
+
     - name:       toolbelt
       type:       github-release
       repository: cloudfoundry-community/toolbelt-boshrelease

--- a/hooks/addon-add-peer~ap.pm
+++ b/hooks/addon-add-peer~ap.pm
@@ -1,0 +1,97 @@
+package Genesis::Hook::Addon::Jumpbox::AddPeer v3.0.0;
+
+use v5.20;
+use warnings; # Genesis min perl version is 5.20
+
+# Only needed for development
+BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
+
+use parent qw(Genesis::Hook::Addon);
+use Genesis qw/bail info run/;
+
+# Include WireGuard key/peer helpers from mixin
+BEGIN {
+	require File::Basename;
+	my $mixin_file = File::Basename::dirname(__FILE__) . '/lib/_wireguard_keys.pm';
+	do $mixin_file or die "Failed to include addon mixin $mixin_file: $!";
+}
+
+sub init {
+	my $class = shift;
+	my $obj = $class->SUPER::init(@_);
+	$obj->check_minimum_genesis_version('3.1.0');
+	return $obj;
+}
+
+sub cmd_details {
+	return
+	"Register a new WireGuard peer in the vault registry.\n".
+	"Generates a keypair and preshared key, allocates the lowest free\n".
+	"tunnel address, and stores everything in vault. The peer becomes\n".
+	"active on the next deploy (applied via wg syncconf - no tunnel drop).\n".
+	"Usage: genesis do <env> -- add-peer <name> [extra-allowed-cidr ...]\n".
+	"This addon requires the 'wireguard' feature to be enabled.\n";
+}
+
+sub perform {
+	my ($self) = @_;
+
+	$self->require_wireguard();
+
+	my @args = @{$self->{args}};
+	bail("USAGE: genesis do <env> -- add-peer <name> [extra-allowed-cidr ...]")
+		unless @args;
+
+	my ($name, @extra_cidrs) = @args;
+	bail("Peer name must match [a-zA-Z0-9._\@-]+, got '%s'", $name)
+		unless $name =~ /^[a-zA-Z0-9._\@-]+$/;
+	for my $cidr (@extra_cidrs) {
+		bail("Invalid extra allowed CIDR '%s'", $cidr)
+			unless $cidr =~ m{^\d+\.\d+\.\d+\.\d+/\d+$};
+	}
+
+	my $peer_path = $self->_wg_peers_base . $name;
+	my (undef, $exists_rc) = run({stderr => 0},
+		'safe --quiet exists "$1"', $peer_path);
+	bail(
+		"Peer '%s' already exists. Remove it first with:\n".
+		"  genesis do %s -- remove-peer %s",
+		$name, $ENV{GENESIS_ENVIRONMENT}, $name
+	) if $exists_rc == 0;
+
+	my $cidr = $self->env->lookup('params.wireguard_cidr', '10.20.31.0/24');
+	my $address = $self->_wg_alloc_address($cidr);
+	my ($priv, $pub) = $self->_wg_keypair;
+	my $psk = $self->_wg_genpsk;
+	my $allowed = join(',', "$address/32", @extra_cidrs);
+
+	my (undef, $rc) = run({stderr => 0},
+		'safe set "$1" "private=$2" "public=$3" "psk=$4" "address=$5" "allowed_ips=$6" "created=$7"',
+		$peer_path, $priv, $pub, $psk, $address, $allowed, time());
+	bail("Failed to store peer '%s' at %s", $name, $peer_path) if $rc;
+
+	info("");
+	info("Registered peer #C{%s}", $name);
+	info("  address:     %s", $address);
+	info("  allowed_ips: %s", $allowed);
+	info("  public key:  %s", $pub);
+	info("");
+	info("Activate the peer with:");
+	info("  #G{genesis deploy $ENV{GENESIS_ENVIRONMENT}}");
+	info("");
+	info("Then emit its client config with:");
+	info("  #G{genesis do $ENV{GENESIS_ENVIRONMENT} -- generate-wg-config %s}", $name);
+
+	return $self->done();
+}
+
+sub require_wireguard {
+	my ($self) = @_;
+	if (!$self->env->has_feature('wireguard')) {
+		bail("This addon requires the 'wireguard' feature to be activated in the $ENV{GENESIS_ENVIRONMENT} environment.");
+	}
+	return 1;
+}
+
+1;
+# vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:

--- a/hooks/addon-add-peer~ap.pm
+++ b/hooks/addon-add-peer~ap.pm
@@ -29,7 +29,7 @@ sub cmd_details {
 	"Generates a keypair and preshared key, allocates the lowest free\n".
 	"tunnel address, and stores everything in vault. The peer becomes\n".
 	"active on the next deploy (applied via wg syncconf - no tunnel drop).\n".
-	"Usage: genesis do <env> -- add-peer <name> [extra-allowed-cidr ...]\n".
+	"Usage: genesis <env> do add-peer <name> [extra-allowed-cidr ...]\n".
 	"This addon requires the 'wireguard' feature to be enabled.\n";
 }
 
@@ -39,7 +39,7 @@ sub perform {
 	$self->require_wireguard();
 
 	my @args = @{$self->{args}};
-	bail("USAGE: genesis do <env> -- add-peer <name> [extra-allowed-cidr ...]")
+	bail("USAGE: genesis <env> do add-peer <name> [extra-allowed-cidr ...]")
 		unless @args;
 
 	my ($name, @extra_cidrs) = @args;
@@ -55,7 +55,7 @@ sub perform {
 		'safe --quiet exists "$1"', $peer_path);
 	bail(
 		"Peer '%s' already exists. Remove it first with:\n".
-		"  genesis do %s -- remove-peer %s",
+		"  genesis %s do remove-peer %s",
 		$name, $ENV{GENESIS_ENVIRONMENT}, $name
 	) if $exists_rc == 0;
 
@@ -80,7 +80,7 @@ sub perform {
 	info("  #G{genesis deploy $ENV{GENESIS_ENVIRONMENT}}");
 	info("");
 	info("Then emit its client config with:");
-	info("  #G{genesis do $ENV{GENESIS_ENVIRONMENT} -- generate-wg-config %s}", $name);
+	info("  #G{genesis $ENV{GENESIS_ENVIRONMENT} do generate-wg-config %s}", $name);
 
 	return $self->done();
 }

--- a/hooks/addon-generate-vpn-config~gv.pm
+++ b/hooks/addon-generate-vpn-config~gv.pm
@@ -26,7 +26,7 @@ sub init {
 sub cmd_details {
 	return
 	"Generate a client certificate (if missing) and an openvpn config file for a given user.\n".
-	"Usage: genesis do <env> -- generate-vpn-config [-f] user\@email.addr.ess\n".
+	"Usage: genesis <env> do generate-vpn-config [-f] user\@email.addr.ess\n".
 	"Options:\n".
 	"  -f  Force regeneration of the certificate even if it already exists\n".
 	"This addon requires the 'openvpn' feature to be enabled.\n";
@@ -41,7 +41,7 @@ sub perform {
 	# Parse arguments
 	my @args = @{$self->{args}};
 	if (scalar(@args) == 0 || (scalar(@args) == 1 && $args[0] eq '-f')) {
-		bail("USAGE: genesis do <env> generate-vpn-config [-f] user\@email.addr.ess");
+		bail("USAGE: genesis <env> do generate-vpn-config [-f] user\@email.addr.ess");
 	}
 
 	my $regen = '';

--- a/hooks/addon-generate-wg-config~gw.pm
+++ b/hooks/addon-generate-wg-config~gw.pm
@@ -1,0 +1,117 @@
+package Genesis::Hook::Addon::Jumpbox::GenerateWgConfig v3.0.0;
+
+use v5.20;
+use warnings; # Genesis min perl version is 5.20
+
+# Only needed for development
+BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
+
+use parent qw(Genesis::Hook::Addon);
+use Genesis qw/bail info run read_json_from/;
+
+# Include WireGuard key/peer helpers and jumpbox IP lookup from mixins
+BEGIN {
+	require File::Basename;
+	for my $mixin (qw(_wireguard_keys.pm _get_jumpbox_ip.pm)) {
+		my $mixin_file = File::Basename::dirname(__FILE__) . "/lib/$mixin";
+		do $mixin_file or die "Failed to include addon mixin $mixin_file: $!";
+	}
+}
+
+sub init {
+	my $class = shift;
+	my $obj = $class->SUPER::init(@_);
+	$obj->check_minimum_genesis_version('3.1.0');
+	return $obj;
+}
+
+sub cmd_details {
+	return
+	"Emit a wg-quick client configuration for a registered peer.\n".
+	"Usage: genesis do <env> -- generate-wg-config [-q] <name>\n".
+	"Options:\n".
+	"  -q  Also render the config as a terminal QR code (requires qrencode)\n".
+	"The endpoint comes from params.wireguard_endpoint, falling back to\n".
+	"the deployed jumpbox VM's IP.\n".
+	"This addon requires the 'wireguard' feature to be enabled.\n";
+}
+
+sub perform {
+	my ($self) = @_;
+
+	$self->require_wireguard();
+
+	my %opts = $self->parse_options([ 'qr|q' ]);
+	my @args = @{$self->{args}};
+	bail("USAGE: genesis do <env> -- generate-wg-config [-q] <name>")
+		unless @args == 1;
+	my ($name) = @args;
+
+	my $peer_path = $self->_wg_peers_base . $name;
+	my (undef, $exists_rc) = run({stderr => 0},
+		'safe --quiet exists "$1"', $peer_path);
+	bail(
+		"Peer '%s' is not registered. Add it with:\n".
+		"  genesis do %s -- add-peer %s",
+		$name, $ENV{GENESIS_ENVIRONMENT}, $name
+	) if $exists_rc != 0;
+
+	my $priv    = $self->_wg_peer_get($name, 'private')
+		or bail("Peer '%s' has no private key in vault", $name);
+	my $psk     = $self->_wg_peer_get($name, 'psk');
+	my $address = $self->_wg_peer_get($name, 'address')
+		or bail("Peer '%s' has no address in vault", $name);
+
+	my ($server_pub, $pub_rc) = run({stderr => 0},
+		'safe get "$1:public"', $self->_wg_server_path);
+	bail("Server public key not found at %s", $self->_wg_server_path) if $pub_rc;
+	chomp($server_pub);
+
+	# Endpoint: params -> jumpbox VM IP
+	my $port = $self->env->lookup('params.wireguard_port', '51820');
+	my $endpoint = $self->env->lookup('params.wireguard_endpoint', '');
+	$endpoint ||= $self->_get_jumpbox_ip();
+	bail("Cannot determine the WireGuard endpoint — set params.wireguard_endpoint")
+		unless $endpoint;
+	$endpoint .= ":$port" unless $endpoint =~ /:\d+$/;
+
+	# Client-side routes: the tunnel network plus any routed networks.
+	my $cidr = $self->env->lookup('params.wireguard_cidr', '10.20.31.0/24');
+	my $routed = $self->env->lookup('params.wireguard_routed_networks', []);
+	my @allowed = ($cidr, (ref $routed eq 'ARRAY' ? @$routed : ()));
+
+	my $dns = $self->env->lookup('params.wireguard_dns', []);
+	my @dns = ref $dns eq 'ARRAY' ? @$dns : ($dns);
+
+	my $config = "[Interface]\n";
+	$config .= "PrivateKey = $priv\n";
+	$config .= "Address = $address/32\n";
+	$config .= "DNS = " . join(', ', @dns) . "\n" if @dns;
+	$config .= "\n[Peer]\n";
+	$config .= "PublicKey = $server_pub\n";
+	$config .= "PresharedKey = $psk\n" if $psk;
+	$config .= "Endpoint = $endpoint\n";
+	$config .= "AllowedIPs = " . join(', ', @allowed) . "\n";
+	$config .= "PersistentKeepalive = 25\n";
+
+	print $config;
+
+	if ($opts{qr}) {
+		my (undef, $qr_missing) = run({stderr => 0}, 'command -v qrencode');
+		bail("qrencode not found in PATH — install it for -q output") if $qr_missing;
+		run({interactive => 1}, 'printf \'%s\' "$1" | qrencode -t ansiutf8', $config);
+	}
+
+	return $self->done();
+}
+
+sub require_wireguard {
+	my ($self) = @_;
+	if (!$self->env->has_feature('wireguard')) {
+		bail("This addon requires the 'wireguard' feature to be activated in the $ENV{GENESIS_ENVIRONMENT} environment.");
+	}
+	return 1;
+}
+
+1;
+# vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:

--- a/hooks/addon-generate-wg-config~gw.pm
+++ b/hooks/addon-generate-wg-config~gw.pm
@@ -28,7 +28,7 @@ sub init {
 sub cmd_details {
 	return
 	"Emit a wg-quick client configuration for a registered peer.\n".
-	"Usage: genesis do <env> -- generate-wg-config [-q] <name>\n".
+	"Usage: genesis <env> do generate-wg-config [-q] <name>\n".
 	"Options:\n".
 	"  -q  Also render the config as a terminal QR code (requires qrencode)\n".
 	"The endpoint comes from params.wireguard_endpoint, falling back to\n".
@@ -43,7 +43,7 @@ sub perform {
 
 	my %opts = $self->parse_options([ 'qr|q' ]);
 	my @args = @{$self->{args}};
-	bail("USAGE: genesis do <env> -- generate-wg-config [-q] <name>")
+	bail("USAGE: genesis <env> do generate-wg-config [-q] <name>")
 		unless @args == 1;
 	my ($name) = @args;
 
@@ -52,7 +52,7 @@ sub perform {
 		'safe --quiet exists "$1"', $peer_path);
 	bail(
 		"Peer '%s' is not registered. Add it with:\n".
-		"  genesis do %s -- add-peer %s",
+		"  genesis %s do add-peer %s",
 		$name, $ENV{GENESIS_ENVIRONMENT}, $name
 	) if $exists_rc != 0;
 

--- a/hooks/addon-issue-cert~ic.pm
+++ b/hooks/addon-issue-cert~ic.pm
@@ -19,7 +19,7 @@ sub init {
 sub cmd_details {
 	return
 	"Issue a new VPN certificate to a named user, so that they can access the VPN.\n".
-	"Usage: genesis do <env> -- issue-cert user\@email.addr.ess\n".
+	"Usage: genesis <env> do issue-cert user\@email.addr.ess\n".
 	"This addon requires the 'openvpn' feature to be enabled.\n";
 }
 
@@ -32,7 +32,7 @@ sub perform {
 	# Get email from arguments
 	my $email = $self->{args}[0];
 	if (!$email) {
-		bail("USAGE: genesis do <env> -- issue-cert user\@email.addr.ess");
+		bail("USAGE: genesis <env> do issue-cert user\@email.addr.ess");
 	}
 
 	my $secret = "$ENV{GENESIS_SECRETS_BASE}openvpn/certs/users/$email";

--- a/hooks/addon-list-peers~lp.pm
+++ b/hooks/addon-list-peers~lp.pm
@@ -1,0 +1,74 @@
+package Genesis::Hook::Addon::Jumpbox::ListPeers v3.0.0;
+
+use v5.20;
+use warnings; # Genesis min perl version is 5.20
+
+# Only needed for development
+BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
+
+use parent qw(Genesis::Hook::Addon);
+use Genesis qw/bail info/;
+
+# Include WireGuard key/peer helpers from mixin
+BEGIN {
+	require File::Basename;
+	my $mixin_file = File::Basename::dirname(__FILE__) . '/lib/_wireguard_keys.pm';
+	do $mixin_file or die "Failed to include addon mixin $mixin_file: $!";
+}
+
+sub init {
+	my $class = shift;
+	my $obj = $class->SUPER::init(@_);
+	$obj->check_minimum_genesis_version('3.1.0');
+	return $obj;
+}
+
+sub cmd_details {
+	return
+	"List WireGuard peers registered in the vault registry.\n".
+	"Usage: genesis do <env> -- list-peers\n".
+	"This addon requires the 'wireguard' feature to be enabled.\n";
+}
+
+sub perform {
+	my ($self) = @_;
+
+	$self->require_wireguard();
+
+	my @names = $self->_wg_list_peers;
+	if (!@names) {
+		info("No peers registered. Add one with:");
+		info("  #G{genesis do $ENV{GENESIS_ENVIRONMENT} -- add-peer <name>}");
+		return $self->done();
+	}
+
+	info("");
+	info("Registered WireGuard peers:");
+	for my $name (@names) {
+		my $address = $self->_wg_peer_get($name, 'address')     || '?';
+		my $allowed = $self->_wg_peer_get($name, 'allowed_ips') || '?';
+		my $created = $self->_wg_peer_get($name, 'created');
+		my $when = $created
+			? do {
+					my @t = gmtime($created);
+					sprintf('%04d-%02d-%02d', $t[5]+1900, $t[4]+1, $t[3]);
+				}
+			: '?';
+		info("  #C{%-24s} %-16s %-10s %s", $name, $address, $when, $allowed);
+	}
+	info("");
+	info("(%d peer%s)", scalar(@names), @names == 1 ? '' : 's');
+
+	return $self->done();
+}
+
+sub require_wireguard {
+	my ($self) = @_;
+	if (!$self->env->has_feature('wireguard')) {
+		bail("This addon requires the 'wireguard' feature to be activated in the $ENV{GENESIS_ENVIRONMENT} environment.");
+	}
+	return 1;
+}
+
+1;
+# vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:

--- a/hooks/addon-list-peers~lp.pm
+++ b/hooks/addon-list-peers~lp.pm
@@ -26,7 +26,7 @@ sub init {
 sub cmd_details {
 	return
 	"List WireGuard peers registered in the vault registry.\n".
-	"Usage: genesis do <env> -- list-peers\n".
+	"Usage: genesis <env> do list-peers\n".
 	"This addon requires the 'wireguard' feature to be enabled.\n";
 }
 
@@ -38,7 +38,7 @@ sub perform {
 	my @names = $self->_wg_list_peers;
 	if (!@names) {
 		info("No peers registered. Add one with:");
-		info("  #G{genesis do $ENV{GENESIS_ENVIRONMENT} -- add-peer <name>}");
+		info("  #G{genesis $ENV{GENESIS_ENVIRONMENT} do add-peer <name>}");
 		return $self->done();
 	}
 

--- a/hooks/addon-reissue-cert~ri.pm
+++ b/hooks/addon-reissue-cert~ri.pm
@@ -19,7 +19,7 @@ sub init {
 sub cmd_details {
 	return
 	"Re-issue a VPN user certificate, regenerating the user's key. The old certificate will be revoked.\n".
-	"Usage: genesis do <env> -- reissue-cert user\@email.addr.ess\n".
+	"Usage: genesis <env> do reissue-cert user\@email.addr.ess\n".
 	"This addon requires the 'openvpn' feature to be enabled.\n";
 }
 
@@ -32,7 +32,7 @@ sub perform {
 	# Get email from arguments
 	my $email = $self->{args}[0];
 	if (!$email) {
-		bail("USAGE: genesis do <env> -- reissue-cert user\@email.addr.ess");
+		bail("USAGE: genesis <env> do reissue-cert user\@email.addr.ess");
 	}
 
 	my $secret = "$ENV{GENESIS_SECRETS_BASE}openvpn/certs/users/$email";

--- a/hooks/addon-remove-peer~rp.pm
+++ b/hooks/addon-remove-peer~rp.pm
@@ -1,0 +1,73 @@
+package Genesis::Hook::Addon::Jumpbox::RemovePeer v3.0.0;
+
+use v5.20;
+use warnings; # Genesis min perl version is 5.20
+
+# Only needed for development
+BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
+
+use parent qw(Genesis::Hook::Addon);
+use Genesis qw/bail info run/;
+
+# Include WireGuard key/peer helpers from mixin
+BEGIN {
+	require File::Basename;
+	my $mixin_file = File::Basename::dirname(__FILE__) . '/lib/_wireguard_keys.pm';
+	do $mixin_file or die "Failed to include addon mixin $mixin_file: $!";
+}
+
+sub init {
+	my $class = shift;
+	my $obj = $class->SUPER::init(@_);
+	$obj->check_minimum_genesis_version('3.1.0');
+	return $obj;
+}
+
+sub cmd_details {
+	return
+	"Revoke a WireGuard peer: its registry entry moves to the revoked/\n".
+	"archive and the next deploy drops it from the interface config.\n".
+	"Usage: genesis do <env> -- remove-peer <name>\n".
+	"This addon requires the 'wireguard' feature to be enabled.\n";
+}
+
+sub perform {
+	my ($self) = @_;
+
+	$self->require_wireguard();
+
+	my @args = @{$self->{args}};
+	bail("USAGE: genesis do <env> -- remove-peer <name>")
+		unless @args == 1;
+
+	my ($name) = @args;
+	my $peer_path = $self->_wg_peers_base . $name;
+
+	my (undef, $exists_rc) = run({stderr => 0},
+		'safe --quiet exists "$1"', $peer_path);
+	bail("Peer '%s' is not registered", $name) if $exists_rc != 0;
+
+	my $revoked_path = $self->_wg_revoked_base . $name . '-' . time();
+	my (undef, $rc) = run({stderr => 0},
+		'safe mv "$1" "$2"', $peer_path, $revoked_path);
+	bail("Failed to move peer '%s' to %s", $name, $revoked_path) if $rc;
+
+	info("");
+	info("Peer #C{%s} moved to #Y{%s}", $name, $revoked_path);
+	info("");
+	info("Revocation takes effect on the next deploy:");
+	info("  #G{genesis deploy $ENV{GENESIS_ENVIRONMENT}}");
+
+	return $self->done();
+}
+
+sub require_wireguard {
+	my ($self) = @_;
+	if (!$self->env->has_feature('wireguard')) {
+		bail("This addon requires the 'wireguard' feature to be activated in the $ENV{GENESIS_ENVIRONMENT} environment.");
+	}
+	return 1;
+}
+
+1;
+# vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:

--- a/hooks/addon-remove-peer~rp.pm
+++ b/hooks/addon-remove-peer~rp.pm
@@ -27,7 +27,7 @@ sub cmd_details {
 	return
 	"Revoke a WireGuard peer: its registry entry moves to the revoked/\n".
 	"archive and the next deploy drops it from the interface config.\n".
-	"Usage: genesis do <env> -- remove-peer <name>\n".
+	"Usage: genesis <env> do remove-peer <name>\n".
 	"This addon requires the 'wireguard' feature to be enabled.\n";
 }
 
@@ -37,7 +37,7 @@ sub perform {
 	$self->require_wireguard();
 
 	my @args = @{$self->{args}};
-	bail("USAGE: genesis do <env> -- remove-peer <name>")
+	bail("USAGE: genesis <env> do remove-peer <name>")
 		unless @args == 1;
 
 	my ($name) = @args;

--- a/hooks/addon-renew-cert~rn.pm
+++ b/hooks/addon-renew-cert~rn.pm
@@ -19,7 +19,7 @@ sub init {
 sub cmd_details {
 	return
 	"Renew the lifetime of a previously-issued VPN certificate for the specified user, without replacing the key.\n".
-	"Usage: genesis do <env> -- renew-cert user\@email.addr.ess\n".
+	"Usage: genesis <env> do renew-cert user\@email.addr.ess\n".
 	"This addon requires the 'openvpn' feature to be enabled.\n";
 }
 
@@ -32,7 +32,7 @@ sub perform {
 	# Get email from arguments
 	my $email = $self->{args}[0];
 	if (!$email) {
-		bail("USAGE: genesis do <env> -- renew-cert user\@email.addr.ess");
+		bail("USAGE: genesis <env> do renew-cert user\@email.addr.ess");
 	}
 
 	my $secret = "$ENV{GENESIS_SECRETS_BASE}openvpn/certs/users/$email";

--- a/hooks/addon-revoke-cert~rc.pm
+++ b/hooks/addon-revoke-cert~rc.pm
@@ -19,7 +19,7 @@ sub init {
 sub cmd_details {
 	return
 	"Revokes an issued VPN user certificate, preventing them from accessing the VPN.\n".
-	"Usage: genesis do <env> -- revoke-cert user\@email.addr.ess\n".
+	"Usage: genesis <env> do revoke-cert user\@email.addr.ess\n".
 	"This addon requires the 'openvpn' feature to be enabled.\n";
 }
 
@@ -32,7 +32,7 @@ sub perform {
 	# Get email from arguments
 	my $email = $self->{args}[0];
 	if (!$email) {
-		bail("USAGE: genesis do <env> -- revoke-cert user\@email.addr.ess");
+		bail("USAGE: genesis <env> do revoke-cert user\@email.addr.ess");
 	}
 
 	my $secret = "$ENV{GENESIS_SECRETS_BASE}openvpn/certs/users/$email";

--- a/hooks/addon-users~us.pm
+++ b/hooks/addon-users~us.pm
@@ -58,13 +58,13 @@ sub init {
 sub cmd_details {
   return
   "Manage users from GitHub/GitLab SSH keys in ./ops/users.yml\n".
-  "Usage: genesis do <env> -- users <init|add|a|remove|r> <[github|gitlab/]username_1> [username_2 ...]\n".
+  "Usage: genesis <env> do users <init|add|a|remove|r> <[github|gitlab/]username_1> [username_2 ...]\n".
   "Examples:\n".
-  "  genesis do <env> -- users init                        # Sync users from Vault config to environment\n".
-  "  genesis do <env> -- users add dennisjbell gitlab/wayneeseguin github/krutten\n".
-  "  genesis do <env> -- users remove jsmith\n".
-  "  genesis do <env> -- users add ./keys/jsmith.pub       # Local pubkey file\n".
-  "  genesis do <env> -- users add /path/to/pubkeys/       # Directory of pubkeys\n";
+  "  genesis <env> do users init                        # Sync users from Vault config to environment\n".
+  "  genesis <env> do users add dennisjbell gitlab/wayneeseguin github/krutten\n".
+  "  genesis <env> do users remove jsmith\n".
+  "  genesis <env> do users add ./keys/jsmith.pub       # Local pubkey file\n".
+  "  genesis <env> do users add /path/to/pubkeys/       # Directory of pubkeys\n";
 }
 
 sub perform {
@@ -72,8 +72,8 @@ sub perform {
 
   # Check if we have enough arguments
   unless (scalar(@{$self->{args}}) >= 1) {
-    error("Usage: genesis do <env> -- users <init|add|a|remove|r> <[github|gitlab/]username_1> [username_2 ...]");
-    info("Examples:\n  genesis do <env> -- users init\n  genesis do <env> -- users add dennisjbell gitlab/wayneeseguin github/krutten");
+    error("Usage: genesis <env> do users <init|add|a|remove|r> <[github|gitlab/]username_1> [username_2 ...]");
+    info("Examples:\n  genesis <env> do users init\n  genesis <env> do users add dennisjbell gitlab/wayneeseguin github/krutten");
     return 0;
   }
 

--- a/hooks/blueprint.pm
+++ b/hooks/blueprint.pm
@@ -8,7 +8,14 @@ use v5.20;
 BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
 use parent qw(Genesis::Hook::Blueprint);
 
-use Genesis qw/bail warning mkfile_or_fail/;
+use Genesis qw/bail warning mkfile_or_fail run/;
+
+# Include WireGuard key/peer helpers from mixin
+BEGIN {
+  require File::Basename;
+  my $mixin_file = File::Basename::dirname(__FILE__) . '/lib/_wireguard_keys.pm';
+  do $mixin_file or die "Failed to include hook mixin $mixin_file: $!";
+}
 
 # init - Initialize the hook {{{
 sub init {
@@ -56,6 +63,26 @@ sub perform {
         manifests/releases/openvpn.yml
         manifests/releases/networking.yml
       ));
+    } elsif ($feature eq 'wireguard') {
+      $self->add_files(qw(
+        manifests/addons/wireguard.yml
+        manifests/releases/wireguard.yml
+        manifests/releases/bpm.yml
+      ));
+      $self->add_files('manifests/releases/networking.yml')
+        unless $self->want_feature('openvpn');
+
+      # Server keypair: the credentials DSL cannot generate Curve25519,
+      # so ensure it here (no-op when the pair already exists in vault).
+      $self->_ensure_server_keys;
+
+      # Peer registry: enumerate vault peers into a manifest fragment
+      # with (( vault )) references. Absent when there are no peers yet.
+      if (my $peers_fragment = $self->_render_peers_fragment('jumpbox')) {
+        my $peers_file = "manifests/peers.dynamic.yml";
+        mkfile_or_fail($self->env->kit->path($peers_file), 0644, $peers_fragment);
+        $self->add_files($peers_file);
+      }
     } elsif ($feature =~ /^(bastion|dev-tools)$/) {
       $self->add_files("manifests/${feature}.yml");
     } elsif ($feature eq 'ocfp') {
@@ -68,6 +95,13 @@ sub perform {
       push @invalid, $feature;
     }
   }
+
+  # Both VPNs colocate the networking release's iptables job, whose
+  # FORWARD/POSTROUTING lists would otherwise collide (spruce merges
+  # jobs by name, last file wins). The combined overlay concatenates
+  # both rule sets; it must merge after both addon files.
+  $self->add_files('manifests/addons/openvpn-wireguard.yml')
+    if $self->want_feature('openvpn') && $self->want_feature('wireguard');
 
   if (@invalid) {
     my $noun = @invalid == 1 ? 'feature' : 'features';

--- a/hooks/features.pm
+++ b/hooks/features.pm
@@ -21,7 +21,7 @@ sub perform {
 
 	# Process requested features
 	foreach my $feature (@{$self->{features}}) {
-		if ($feature eq 'openvpn' || $feature eq 'bastion' || $feature eq 'dev-tools' || $feature eq 'ocfp') {
+		if ($feature eq 'openvpn' || $feature eq 'wireguard' || $feature eq 'bastion' || $feature eq 'dev-tools' || $feature eq 'ocfp') {
 			$self->add_feature($feature);
 		}
 		elsif ($feature eq 'shield') {
@@ -44,7 +44,7 @@ sub perform {
 		else {
 			bail(
 				"Feature [$feature] not supported in this context.\n".
-				"Supported features are: openvpn, bastion, dev-tools, and custom ops files."
+				"Supported features are: openvpn, wireguard, bastion, dev-tools, and custom ops files."
 			);
 		}
 	}

--- a/hooks/lib/_wireguard_keys.pm
+++ b/hooks/lib/_wireguard_keys.pm
@@ -1,0 +1,195 @@
+# Shared WireGuard key/peer helpers, included into hook packages via:
+#   do <hooks-dir>/lib/_wireguard_keys.pm
+#
+# WireGuard uses base64 Curve25519 keypairs, which the Genesis
+# credentials DSL cannot generate — so key lifecycle lives here:
+#   server keypair   <secrets-base>server:{private,public}
+#   peer registry    <secrets-base>peers/<name>:{private,public,psk,
+#                      address,allowed_ips,created}
+#   revoked peers    <secrets-base>revoked/<name>-<epoch>
+#
+# Key generation prefers `wg`; falls back to openssl X25519 (raw key
+# extracted from PKCS#8 DER) so hooks work without wireguard-tools.
+
+use Genesis qw/bail run warning/;
+
+# Relative prefix under GENESIS_SECRETS_BASE for wireguard secrets.
+# 'wireguard/' here: the jumpbox kit namespaces its wireguard secrets
+# alongside openvpn/ (the standalone wireguard kit uses '').
+sub _wg_secrets_prefix { 'wireguard/' }
+
+# GENESIS_SECRETS_BASE may carry a leading slash; safe emits paths
+# without one, so normalize it away for consistent matching.
+sub _wg_base {
+	my $base = $ENV{GENESIS_SECRETS_BASE} . $_[0]->_wg_secrets_prefix;
+	$base =~ s{^/}{};
+	return $base;
+}
+sub _wg_server_path { $_[0]->_wg_base . 'server' }
+sub _wg_peers_base  { $_[0]->_wg_base . 'peers/' }
+sub _wg_revoked_base{ $_[0]->_wg_base . 'revoked/' }
+
+# _wg_keypair - generate (private, public) base64 Curve25519 pair {{{
+sub _wg_keypair {
+	my ($self) = @_;
+
+	my ($priv, $rc) = run({stderr => 0}, 'wg genkey 2>/dev/null');
+	$priv = defined($priv) ? $priv : ''; chomp($priv);
+	if (!$rc && $priv) {
+		my ($pub, $prc) = run({stderr => 0}, 'printf \'%s\' "$1" | wg pubkey', $priv);
+		$pub = defined($pub) ? $pub : ''; chomp($pub);
+		return ($priv, $pub) if !$prc && $pub;
+	}
+
+	# openssl X25519 fallback: raw 32-byte keys live at the tail of the
+	# PKCS#8 / SPKI DER encodings.
+	($priv, $rc) = run({stderr => 0},
+		'openssl genpkey -algorithm X25519 -outform DER 2>/dev/null | tail -c 32 | base64');
+	$priv = defined($priv) ? $priv : ''; chomp($priv);
+	bail("Cannot generate a WireGuard keypair: neither wg nor openssl X25519 available")
+		if $rc || !$priv;
+
+	my ($pub, $prc) = run({stderr => 0},
+		'{ printf \'\x30\x2e\x02\x01\x00\x30\x05\x06\x03\x2b\x65\x6e\x04\x22\x04\x20\'; '.
+		'printf \'%s\' "$1" | base64 -d; } | openssl pkey -inform DER -pubout -outform DER 2>/dev/null '.
+		'| tail -c 32 | base64', $priv);
+	$pub = defined($pub) ? $pub : ''; chomp($pub);
+	bail("Cannot derive WireGuard public key via openssl") if $prc || !$pub;
+
+	return ($priv, $pub);
+}
+# }}}
+
+# _wg_genpsk - generate a base64 preshared key {{{
+sub _wg_genpsk {
+	my ($self) = @_;
+	my ($psk, $rc) = run({stderr => 0}, 'wg genpsk 2>/dev/null');
+	$psk = defined($psk) ? $psk : ''; chomp($psk);
+	return $psk if !$rc && $psk;
+
+	($psk, $rc) = run({stderr => 0}, 'head -c 32 /dev/urandom | base64');
+	$psk = defined($psk) ? $psk : ''; chomp($psk);
+	bail("Cannot generate a preshared key") if $rc || !$psk;
+	return $psk;
+}
+# }}}
+
+# _ensure_server_keys - idempotently create the server keypair in vault {{{
+sub _ensure_server_keys {
+	my ($self) = @_;
+	my $path = $self->_wg_server_path;
+
+	my (undef, $rc) = run({stderr => 0},
+		'safe --quiet exists "$1:private" && safe --quiet exists "$1:public"', $path);
+	return 1 if $rc == 0;
+
+	my ($priv, $pub) = $self->_wg_keypair;
+	my (undef, $set_rc) = run({stderr => 0},
+		'safe set "$1" "private=$2" "public=$3"',
+		$path, $priv, $pub);
+	bail("Failed to store WireGuard server keypair at %s", $path) if $set_rc;
+	return 1;
+}
+# }}}
+
+# _wg_list_peers - names registered under the peer registry {{{
+sub _wg_list_peers {
+	my ($self) = @_;
+	my $base = $self->_wg_peers_base;
+	my ($out, $rc, $err) = run({stderr => 0}, 'safe paths "$1"', $base);
+	if ($rc) {
+		# An empty registry reads as "no secret exists" — only complain
+		# about other failures (unreachable vault, auth, ...).
+		warning(
+			"wireguard peer registry lookup failed (safe paths %s): %s",
+			$base, $err || 'no output'
+		) unless ($err || '') =~ /no secret exists/;
+		return ();
+	}
+	return () if !$out;
+	my %seen;
+	for my $line (split /\n/, $out) {
+		next unless $line =~ /^\Q$base\E(.+)$/;
+		$seen{$1} = 1;
+	}
+	return sort keys %seen;
+}
+# }}}
+
+# _wg_peer_get - fetch one key of a registered peer {{{
+sub _wg_peer_get {
+	my ($self, $name, $key) = @_;
+	my ($out, $rc) = run({stderr => 0},
+		'safe get "$1:$2"', $self->_wg_peers_base . $name, $key);
+	return undef if $rc;
+	$out = defined($out) ? $out : ''; chomp($out);
+	return $out;
+}
+# }}}
+
+# _wg_alloc_address - lowest free host >= .2 in the given CIDR {{{
+# .1 is the server by convention.
+sub _wg_alloc_address {
+	my ($self, $cidr) = @_;
+	my ($ip, $bits) = $cidr =~ m{^(\d+\.\d+\.\d+\.\d+)/(\d+)$}
+		or bail("Invalid wireguard_cidr '%s' — expected a.b.c.d/nn", $cidr);
+	bail("wireguard_cidr prefix /%s too small for peer allocation", $bits) if $bits > 30;
+
+	my $to_int   = sub { my @o = split /\./, $_[0]; ($o[0]<<24)|($o[1]<<16)|($o[2]<<8)|$o[3] };
+	my $to_quad  = sub { join '.', ($_[0]>>24)&255, ($_[0]>>16)&255, ($_[0]>>8)&255, $_[0]&255 };
+	my $mask     = $bits == 0 ? 0 : (0xFFFFFFFF << (32 - $bits)) & 0xFFFFFFFF;
+	my $network  = $to_int->($ip) & $mask;
+	my $broadcast= $network | (~$mask & 0xFFFFFFFF);
+
+	my %taken;
+	for my $name ($self->_wg_list_peers) {
+		my $addr = $self->_wg_peer_get($name, 'address') or next;
+		$taken{$addr} = 1;
+	}
+
+	for (my $host = $network + 2; $host < $broadcast; $host++) {
+		my $candidate = $to_quad->($host);
+		return $candidate unless $taken{$candidate};
+	}
+	bail("No free addresses left in %s", $cidr);
+}
+# }}}
+
+# _render_peers_fragment - manifest fragment enumerating vault peers {{{
+# Returns undef when the registry is empty so first deploys and spec
+# runs stay green. Key material is referenced via (( vault )) ops —
+# never rendered literally.
+sub _render_peers_fragment {
+	my ($self, $ig_name) = @_;
+	$ig_name ||= 'wireguard';
+
+	my @names = $self->_wg_list_peers;
+	return undef unless @names;
+
+	my $base = $self->_wg_peers_base;
+	my $yaml = <<"EOF";
+instance_groups:
+- name: $ig_name
+  jobs:
+  - name: wireguard
+    properties:
+      wireguard:
+        peers:
+EOF
+	for my $name (@names) {
+		my $allowed = $self->_wg_peer_get($name, 'allowed_ips');
+		bail("Peer '%s' in vault registry is missing allowed_ips", $name)
+			unless $allowed;
+		my @allowed = grep { length } split /[,\s]+/, $allowed;
+		$yaml .= "        - name: $name\n";
+		$yaml .= "          public_key: (( vault \"$base$name:public\" ))\n";
+		$yaml .= "          preshared_key: (( vault \"$base$name:psk\" ))\n";
+		$yaml .= "          allowed_ips:\n";
+		$yaml .= "          - $_\n" for @allowed;
+	}
+	return $yaml;
+}
+# }}}
+
+1;
+# vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:

--- a/hooks/new.pm
+++ b/hooks/new.pm
@@ -9,7 +9,7 @@ BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/
 use parent qw(Genesis::Hook);
 
 use Genesis qw/mkfile_or_fail bail/;
-use Genesis::UI qw/prompt_for_boolean prompt_for_line/;
+use Genesis::UI qw/prompt_for_boolean prompt_for_line prompt_for_list/;
 
 # init - Initialize the hook {{{
 sub init {
@@ -45,14 +45,52 @@ sub perform {
     );
   }
 
+  # WireGuard configuration
+  my $wireguard = prompt_for_boolean(
+    'Would you like to provide a WireGuard VPN on this jumpbox?'
+  );
+
+  my ($wg_cidr, $wg_server_address, $wg_port, $wg_endpoint);
+  my (@wg_routed_networks, @wg_dns);
+
+  if ($wireguard) {
+    $wg_cidr = prompt_for_line(
+      'What network should WireGuard clients use? (CIDR format)',
+      { default => '10.20.31.0/24', validation => qr{^\d+\.\d+\.\d+\.\d+/\d+$} }
+    );
+    my ($net_base) = $wg_cidr =~ m{^(\d+\.\d+\.\d+)\.};
+    $wg_server_address = "$net_base.1/" . ($wg_cidr =~ m{/(\d+)$})[0];
+
+    $wg_port = prompt_for_line(
+      'What UDP port should WireGuard listen on?',
+      { default => '51820', validation => qr/^\d+$/ }
+    );
+
+    @wg_routed_networks = @{prompt_for_list('line',
+      'What networks should be reachable through WireGuard? (CIDR format, e.g. 10.4.0.0/16)',
+      'network'
+    )};
+
+    @wg_dns = @{prompt_for_list('line',
+      'What DNS servers should clients use over WireGuard?',
+      'DNS server'
+    )};
+
+    $wg_endpoint = prompt_for_line(
+      'What public endpoint (host or host:port) will WireGuard clients dial? (leave empty to derive from BOSH)',
+      { default => '' }
+    );
+  }
+
   # Build environment file content
   my $file_content = "kit:\n";
   $file_content .= "  name:    $ENV{GENESIS_KIT_NAME}\n";
   $file_content .= "  version: $ENV{GENESIS_KIT_VERSION}\n";
 
-  if ($openvpn) {
+  if ($openvpn || $wireguard) {
     $file_content .= "  features:\n";
-    $file_content .= "    - openvpn\n";
+    $file_content .= "    - openvpn\n"   if $openvpn;
+    $file_content .= "    - wireguard\n" if $wireguard;
   }
 
   $file_content .= "\n";
@@ -84,6 +122,34 @@ sub perform {
     $params_content .= "  vpn_dns_search_domains:\n";
     for my $domain (@vpn_dns_search_domains) {
       $params_content .= "    - $domain\n";
+    }
+  }
+
+  if ($wireguard) {
+    $params_content .= "  wireguard_cidr: $wg_cidr\n";
+    $params_content .= "  wireguard_server_address: $wg_server_address\n";
+    $params_content .= "  wireguard_port: $wg_port\n" if $wg_port ne '51820';
+    $params_content .= "  wireguard_endpoint: $wg_endpoint\n" if $wg_endpoint;
+
+    if (@wg_routed_networks) {
+      $params_content .= "  wireguard_routed_networks:\n";
+      for my $net (@wg_routed_networks) {
+        $params_content .= "    - $net\n";
+      }
+    }
+
+    $params_content .= "  wireguard_iptables_forward:\n";
+    for my $net (@wg_routed_networks) {
+      $params_content .= "    - -s $wg_cidr -d $net -m conntrack --ctstate NEW -j ACCEPT -m comment --comment 'wg -> lan'\n";
+      $params_content .= "    - -s $net -d $wg_cidr -m conntrack --ctstate NEW -j ACCEPT -m comment --comment 'lan -> wg'\n";
+    }
+    $params_content .= "    - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n";
+
+    if (@wg_dns) {
+      $params_content .= "  wireguard_dns:\n";
+      for my $dns (@wg_dns) {
+        $params_content .= "    - $dns\n";
+      }
     }
   }
 

--- a/manifests/addons/openvpn-wireguard.yml
+++ b/manifests/addons/openvpn-wireguard.yml
@@ -1,0 +1,21 @@
+---
+# Merged iptables rules for openvpn + wireguard coexistence.
+#
+# Both VPN addons colocate the networking release's iptables job; spruce
+# merges jobs by name, so whichever addon file merges last would clobber
+# the other's FORWARD/POSTROUTING lists. This overlay is added by the
+# blueprint hook only when BOTH features are active, after both addon
+# files, and concatenates the two rule sets.
+instance_groups:
+- name: jumpbox
+  jobs:
+  - name: iptables
+    release: networking
+    properties:
+      iptables:
+        filter:
+          FORWARD: (( grab params.vpn_iptables_forward params.wireguard_iptables_forward ))
+        nat:
+          POSTROUTING:
+          - (( concat "-s " params.vpn_client_network "/" params.vpn_client_netmask " -d 0/0 -j MASQUERADE" ))
+          - (( concat "-s " params.wireguard_cidr " -d 0/0 -j MASQUERADE" ))

--- a/manifests/addons/wireguard.yml
+++ b/manifests/addons/wireguard.yml
@@ -1,0 +1,51 @@
+---
+meta:
+  # Full CIDR of the server's in-tunnel address — .1 of wireguard_cidr
+  # by convention (new.pm keeps the two consistent).
+  wireguard_server_address: (( grab params.wireguard_server_address ))
+
+params:
+  # Distinct from openvpn's 172.31.255.0/24 so both VPNs can coexist.
+  wireguard_cidr: 10.20.31.0/24
+  wireguard_server_address: 10.20.31.1/24
+  wireguard_interface: wg0
+  wireguard_port: 51820
+  # Public endpoint (host or host:port) clients dial. Provisioning the
+  # public IP / DNS is terraform's job; this param just carries it into
+  # generate-wg-config.
+  wireguard_endpoint: ""
+  # FORWARD chain rules for the colocated iptables job. new.pm builds
+  # conntrack pairs per routed network; the default only permits
+  # established/related flows.
+  wireguard_iptables_forward:
+  - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+instance_groups:
+- name: jumpbox
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: wireguard
+    release: wireguard
+    properties:
+      wireguard:
+        interface: (( grab params.wireguard_interface ))
+        addresses:
+        - (( grab meta.wireguard_server_address ))
+        listen_port: (( grab params.wireguard_port ))
+        private_key: (( vault meta.vault "/wireguard/server:private" ))
+        public_key: (( vault meta.vault "/wireguard/server:public" ))
+        forwarding:
+          ipv4: true
+        # Peers are enumerated from the vault registry at blueprint time
+        # into manifests/peers.dynamic.yml (see addon add-peer).
+        peers: []
+  - name: iptables
+    release: networking
+    properties:
+      iptables:
+        filter:
+          FORWARD: (( grab params.wireguard_iptables_forward ))
+        nat:
+          POSTROUTING:
+          - (( concat "-s " params.wireguard_cidr " -d 0/0 -j MASQUERADE" ))

--- a/manifests/releases/bpm.yml
+++ b/manifests/releases/bpm.yml
@@ -1,0 +1,5 @@
+releases:
+- name: bpm
+  version: 1.4.22
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.22
+  sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414

--- a/manifests/releases/wireguard.yml
+++ b/manifests/releases/wireguard.yml
@@ -1,0 +1,7 @@
+releases:
+- name: wireguard
+  version: 0.1.0
+  # Unpublished release — build and upload locally until a final release
+  # is published with a downloadable URL and sha256:
+  #   git clone git@github.com:cloudfoundry-community/wireguard-boshrelease.git
+  #   bosh create-release --final --version 0.1.0 && bosh upload-release

--- a/manifests/releases/wireguard.yml
+++ b/manifests/releases/wireguard.yml
@@ -1,7 +1,5 @@
 releases:
 - name: wireguard
   version: 0.1.0
-  # Unpublished release — build and upload locally until a final release
-  # is published with a downloadable URL and sha256:
-  #   git clone git@github.com:cloudfoundry-community/wireguard-boshrelease.git
-  #   bosh create-release --final --version 0.1.0 && bosh upload-release
+  url: https://github.com/cloudfoundry-community/wireguard-boshrelease/releases/download/v0.1.0/wireguard-0.1.0.tgz
+  sha1: c9797384280404c32c5858825f09a535edc23835

--- a/spec/deployments/openvpn-wireguard.yml
+++ b/spec/deployments/openvpn-wireguard.yml
@@ -1,0 +1,26 @@
+---
+kit:
+  name:    dev
+  version: latest
+  features:
+    - openvpn
+    - wireguard
+
+genesis:
+  env:      openvpn-wireguard
+
+params:
+  vpn_client_routes:
+    - 10.1.0.0 255.255.0.0
+  vpn_iptables_forward:
+    - -s 172.31.255.0/24 -d 10.0.0.0/8 -m conntrack --ctstate NEW -j ACCEPT -m comment --comment 'vpn -> lan'
+  vpn_dns_servers:
+    - 1.2.3.4
+  vpn_dns_search_domains:
+    - test.dns.com
+
+  users:
+    - name: test-user
+      shell: /bin/bash
+      ssh_keys:
+        - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm

--- a/spec/deployments/wireguard-all-params.yml
+++ b/spec/deployments/wireguard-all-params.yml
@@ -1,0 +1,32 @@
+---
+kit:
+  name:    dev
+  version: latest
+  features:
+    - wireguard
+
+genesis:
+  env:      wireguard-all-params
+
+params:
+  availability_zones: [z1]
+
+  wireguard_cidr: 10.9.8.0/24
+  wireguard_server_address: 10.9.8.1/24
+  wireguard_interface: wg1
+  wireguard_port: 51821
+  wireguard_endpoint: vpn.example.com:51821
+  wireguard_routed_networks:
+    - 10.4.0.0/16
+  wireguard_dns:
+    - 1.2.3.4
+  wireguard_iptables_forward:
+    - -s 10.9.8.0/24 -d 10.4.0.0/16 -m conntrack --ctstate NEW -j ACCEPT -m comment --comment 'wg -> lan'
+    - -s 10.4.0.0/16 -d 10.9.8.0/24 -m conntrack --ctstate NEW -j ACCEPT -m comment --comment 'lan -> wg'
+    - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+  users:
+    - name: test-user
+      shell: /bin/bash
+      ssh_keys:
+        - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm

--- a/spec/deployments/wireguard.yml
+++ b/spec/deployments/wireguard.yml
@@ -1,0 +1,16 @@
+---
+kit:
+  name:    dev
+  version: latest
+  features:
+    - wireguard
+
+genesis:
+  env:      wireguard
+
+params:
+  users:
+    - name: test-user
+      shell: /bin/bash
+      ssh_keys:
+        - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm

--- a/spec/results/openvpn-wireguard.yml
+++ b/spec/results/openvpn-wireguard.yml
@@ -109,6 +109,8 @@ releases:
   url: http://bosh.io/d/github.com/cloudfoundry/networking-release?v=9
   version: 9
 - name: wireguard
+  sha1: c9797384280404c32c5858825f09a535edc23835
+  url: https://github.com/cloudfoundry-community/wireguard-boshrelease/releases/download/v0.1.0/wireguard-0.1.0.tgz
   version: 0.1.0
 - name: bpm
   sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414

--- a/spec/results/openvpn-wireguard.yml
+++ b/spec/results/openvpn-wireguard.yml
@@ -1,0 +1,126 @@
+exodus:
+  bosh: openvpn-wireguard
+  features: openvpn,wireguard
+  iaas: null
+  is_director: false
+  scale: null
+  services: null
+  use_create_env: false
+instance_groups:
+- azs:
+  - z1
+  env:
+    bosh:
+      remove_dev_tools: true
+  instances: 1
+  jobs:
+  - name: jumpbox
+    properties:
+      jumpbox:
+        banner: null
+        bashrc: null
+        distinct_bosh_user: false
+        env:
+          TMPDIR: /var/vcap/data/root_tmp
+        hostname: openvpn-wireguard-jumpbox
+        hosts: []
+        users:
+        - name: test-user
+          shell: /bin/bash
+          ssh_keys:
+          - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm
+    release: jumpbox
+  - name: inventory
+    release: jumpbox
+  - name: openvpn
+    properties:
+      cipher: AES-256-CBC
+      compress: auto
+      dh_pem: <!{meta.vault}/openvpn/dh_params:dhparam-pem!>
+      extra_configs: []
+      port: 443
+      protocol: tcp
+      push_dns:
+      - 1.2.3.4
+      push_dns_search_domains:
+      - test.dns.com
+      push_routes:
+      - 10.1.0.0 255.255.0.0
+      server: 172.31.255.0 255.255.255.0
+      tls_crl: <!{meta.vault}/openvpn/certs/ca:crl!>
+      tls_server:
+        ca: <!{meta.vault}/openvpn/certs/ca:certificate!>
+        certificate: <!{meta.vault}/openvpn/certs/server:certificate!>
+        private_key: <!{meta.vault}/openvpn/certs/server:key!>
+      tls_version_min: "1.2"
+    release: openvpn
+  - name: iptables
+    properties:
+      iptables:
+        filter:
+          FORWARD:
+          - -s 172.31.255.0/24 -d 10.0.0.0/8 -m conntrack --ctstate NEW -j ACCEPT
+            -m comment --comment 'vpn -> lan'
+          - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        nat:
+          POSTROUTING:
+          - -s 172.31.255.0/255.255.255.0 -d 0/0 -j MASQUERADE
+          - -s 10.20.31.0/24 -d 0/0 -j MASQUERADE
+    release: networking
+  - name: bpm
+    release: bpm
+  - name: wireguard
+    properties:
+      wireguard:
+        addresses:
+        - 10.20.31.1/24
+        forwarding:
+          ipv4: true
+        interface: wg0
+        listen_port: 51820
+        peers: []
+        private_key: <!{meta.vault}/wireguard/server:private!>
+        public_key: <!{meta.vault}/wireguard/server:public!>
+    release: wireguard
+  name: jumpbox
+  networks:
+  - name: jumpbox
+    static_ips:
+    - 10.99.0.16
+  persistent_disk_type: jumpbox
+  stemcell: default
+  vm_type: jumpbox
+name: openvpn-wireguard-jumpbox
+releases:
+- name: jumpbox
+  sha1: 3257fd5b24c624889897f2104672e7cca49fc82e
+  url: https://github.com/cloudfoundry-community/jumpbox-boshrelease/releases/download/v5.1.3/jumpbox-5.1.3.tgz
+  version: 5.1.3
+- name: toolbelt
+  sha1: 9ef47e3aa0f9b22a4186df675f3c223fe3a6d847
+  url: https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v4.0.0/toolbelt-4.0.0.tgz
+  version: 4.0.0
+- name: openvpn
+  sha1: bd35e9bc2b35a3efb7615257c32674e8848137d1
+  url: https://github.com/cloudfoundry-community/openvpn-bosh-release/releases/download/v5.8.5/openvpn-boshrelease-5.8.5.tar.gz
+  version: 5.8.5
+- name: networking
+  sha1: 9b5f9d27917c3754e492470ac6c9af80d62963db
+  url: http://bosh.io/d/github.com/cloudfoundry/networking-release?v=9
+  version: 9
+- name: wireguard
+  version: 0.1.0
+- name: bpm
+  sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.22
+  version: 1.4.22
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+update:
+  canaries: 1
+  canary_watch_time: 1000-60000
+  max_in_flight: 4
+  serial: false
+  update_watch_time: 1000-60000

--- a/spec/results/wireguard-all-params.yml
+++ b/spec/results/wireguard-all-params.yml
@@ -1,0 +1,101 @@
+exodus:
+  bosh: wireguard-all-params
+  features: wireguard
+  iaas: null
+  is_director: false
+  scale: null
+  services: null
+  use_create_env: false
+instance_groups:
+- azs:
+  - z1
+  env:
+    bosh:
+      remove_dev_tools: true
+  instances: 1
+  jobs:
+  - name: jumpbox
+    properties:
+      jumpbox:
+        banner: null
+        bashrc: null
+        distinct_bosh_user: false
+        env:
+          TMPDIR: /var/vcap/data/root_tmp
+        hostname: wireguard-all-params-jumpbox
+        hosts: []
+        users:
+        - name: test-user
+          shell: /bin/bash
+          ssh_keys:
+          - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm
+    release: jumpbox
+  - name: inventory
+    release: jumpbox
+  - name: bpm
+    release: bpm
+  - name: wireguard
+    properties:
+      wireguard:
+        addresses:
+        - 10.9.8.1/24
+        forwarding:
+          ipv4: true
+        interface: wg1
+        listen_port: 51821
+        peers: []
+        private_key: <!{meta.vault}/wireguard/server:private!>
+        public_key: <!{meta.vault}/wireguard/server:public!>
+    release: wireguard
+  - name: iptables
+    properties:
+      iptables:
+        filter:
+          FORWARD:
+          - -s 10.9.8.0/24 -d 10.4.0.0/16 -m conntrack --ctstate NEW -j ACCEPT -m
+            comment --comment 'wg -> lan'
+          - -s 10.4.0.0/16 -d 10.9.8.0/24 -m conntrack --ctstate NEW -j ACCEPT -m
+            comment --comment 'lan -> wg'
+          - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        nat:
+          POSTROUTING:
+          - -s 10.9.8.0/24 -d 0/0 -j MASQUERADE
+    release: networking
+  name: jumpbox
+  networks:
+  - name: jumpbox
+    static_ips:
+    - 10.99.0.16
+  persistent_disk_type: jumpbox
+  stemcell: default
+  vm_type: jumpbox
+name: wireguard-all-params-jumpbox
+releases:
+- name: jumpbox
+  sha1: 3257fd5b24c624889897f2104672e7cca49fc82e
+  url: https://github.com/cloudfoundry-community/jumpbox-boshrelease/releases/download/v5.1.3/jumpbox-5.1.3.tgz
+  version: 5.1.3
+- name: toolbelt
+  sha1: 9ef47e3aa0f9b22a4186df675f3c223fe3a6d847
+  url: https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v4.0.0/toolbelt-4.0.0.tgz
+  version: 4.0.0
+- name: wireguard
+  version: 0.1.0
+- name: bpm
+  sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.22
+  version: 1.4.22
+- name: networking
+  sha1: 9b5f9d27917c3754e492470ac6c9af80d62963db
+  url: http://bosh.io/d/github.com/cloudfoundry/networking-release?v=9
+  version: 9
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+update:
+  canaries: 1
+  canary_watch_time: 1000-60000
+  max_in_flight: 4
+  serial: false
+  update_watch_time: 1000-60000

--- a/spec/results/wireguard-all-params.yml
+++ b/spec/results/wireguard-all-params.yml
@@ -80,6 +80,8 @@ releases:
   url: https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v4.0.0/toolbelt-4.0.0.tgz
   version: 4.0.0
 - name: wireguard
+  sha1: c9797384280404c32c5858825f09a535edc23835
+  url: https://github.com/cloudfoundry-community/wireguard-boshrelease/releases/download/v0.1.0/wireguard-0.1.0.tgz
   version: 0.1.0
 - name: bpm
   sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414

--- a/spec/results/wireguard.yml
+++ b/spec/results/wireguard.yml
@@ -1,0 +1,97 @@
+exodus:
+  bosh: wireguard
+  features: wireguard
+  iaas: null
+  is_director: false
+  scale: null
+  services: null
+  use_create_env: false
+instance_groups:
+- azs:
+  - z1
+  env:
+    bosh:
+      remove_dev_tools: true
+  instances: 1
+  jobs:
+  - name: jumpbox
+    properties:
+      jumpbox:
+        banner: null
+        bashrc: null
+        distinct_bosh_user: false
+        env:
+          TMPDIR: /var/vcap/data/root_tmp
+        hostname: wireguard-jumpbox
+        hosts: []
+        users:
+        - name: test-user
+          shell: /bin/bash
+          ssh_keys:
+          - ssh-rsa 1234567890qwertyuiopasdfghjklzxcvbnm
+    release: jumpbox
+  - name: inventory
+    release: jumpbox
+  - name: bpm
+    release: bpm
+  - name: wireguard
+    properties:
+      wireguard:
+        addresses:
+        - 10.20.31.1/24
+        forwarding:
+          ipv4: true
+        interface: wg0
+        listen_port: 51820
+        peers: []
+        private_key: <!{meta.vault}/wireguard/server:private!>
+        public_key: <!{meta.vault}/wireguard/server:public!>
+    release: wireguard
+  - name: iptables
+    properties:
+      iptables:
+        filter:
+          FORWARD:
+          - -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        nat:
+          POSTROUTING:
+          - -s 10.20.31.0/24 -d 0/0 -j MASQUERADE
+    release: networking
+  name: jumpbox
+  networks:
+  - name: jumpbox
+    static_ips:
+    - 10.99.0.16
+  persistent_disk_type: jumpbox
+  stemcell: default
+  vm_type: jumpbox
+name: wireguard-jumpbox
+releases:
+- name: jumpbox
+  sha1: 3257fd5b24c624889897f2104672e7cca49fc82e
+  url: https://github.com/cloudfoundry-community/jumpbox-boshrelease/releases/download/v5.1.3/jumpbox-5.1.3.tgz
+  version: 5.1.3
+- name: toolbelt
+  sha1: 9ef47e3aa0f9b22a4186df675f3c223fe3a6d847
+  url: https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v4.0.0/toolbelt-4.0.0.tgz
+  version: 4.0.0
+- name: wireguard
+  version: 0.1.0
+- name: bpm
+  sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.22
+  version: 1.4.22
+- name: networking
+  sha1: 9b5f9d27917c3754e492470ac6c9af80d62963db
+  url: http://bosh.io/d/github.com/cloudfoundry/networking-release?v=9
+  version: 9
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+update:
+  canaries: 1
+  canary_watch_time: 1000-60000
+  max_in_flight: 4
+  serial: false
+  update_watch_time: 1000-60000

--- a/spec/results/wireguard.yml
+++ b/spec/results/wireguard.yml
@@ -76,6 +76,8 @@ releases:
   url: https://github.com/cloudfoundry-community/toolbelt-boshrelease/releases/download/v4.0.0/toolbelt-4.0.0.tgz
   version: 4.0.0
 - name: wireguard
+  sha1: c9797384280404c32c5858825f09a535edc23835
+  url: https://github.com/cloudfoundry-community/wireguard-boshrelease/releases/download/v0.1.0/wireguard-0.1.0.tgz
   version: 0.1.0
 - name: bpm
   sha1: sha256:51f2eab4b59939db733beb8f7905e461a732cc29d85e54f151f576cd5bf0c414

--- a/spec/spec_test.go
+++ b/spec/spec_test.go
@@ -32,6 +32,21 @@ var _ = Describe("Jumpbox Kit", func() {
 			CPI:         "aws",
 		})
 		Test(Environment{
+			Name:        "wireguard",
+			CloudConfig: "aws",
+			CPI:         "aws",
+		})
+		Test(Environment{
+			Name:        "wireguard-all-params",
+			CloudConfig: "aws",
+			CPI:         "aws",
+		})
+		Test(Environment{
+			Name:        "openvpn-wireguard",
+			CloudConfig: "aws",
+			CPI:         "aws",
+		})
+		Test(Environment{
 			Name:        "all-features-all-params",
 			CloudConfig: "aws",
 			CPI:         "aws",

--- a/spec/vault/openvpn-wireguard.yml
+++ b/spec/vault/openvpn-wireguard.yml
@@ -1,0 +1,15 @@
+secret/openvpn/wireguard/jumpbox/openvpn/certs/ca:
+  certificate: <!{meta.vault}/openvpn/certs/ca:certificate!>
+  combined: <!{meta.vault}/openvpn/certs/ca:combined!>
+  crl: <!{meta.vault}/openvpn/certs/ca:crl!>
+  key: <!{meta.vault}/openvpn/certs/ca:key!>
+  serial: <!{meta.vault}/openvpn/certs/ca:serial!>
+secret/openvpn/wireguard/jumpbox/openvpn/certs/server:
+  certificate: <!{meta.vault}/openvpn/certs/server:certificate!>
+  combined: <!{meta.vault}/openvpn/certs/server:combined!>
+  key: <!{meta.vault}/openvpn/certs/server:key!>
+secret/openvpn/wireguard/jumpbox/openvpn/dh_params:
+  dhparam-pem: <!{meta.vault}/openvpn/dh_params:dhparam-pem!>
+secret/openvpn/wireguard/jumpbox/wireguard/server:
+  private: <!{meta.vault}/wireguard/server:private!>
+  public: <!{meta.vault}/wireguard/server:public!>

--- a/spec/vault/wireguard-all-params.yml
+++ b/spec/vault/wireguard-all-params.yml
@@ -1,0 +1,3 @@
+secret/wireguard/all/params/jumpbox/wireguard/server:
+  private: <!{meta.vault}/wireguard/server:private!>
+  public: <!{meta.vault}/wireguard/server:public!>

--- a/spec/vault/wireguard.yml
+++ b/spec/vault/wireguard.yml
@@ -1,0 +1,3 @@
+secret/wireguard/jumpbox/wireguard/server:
+  private: <!{meta.vault}/wireguard/server:private!>
+  public: <!{meta.vault}/wireguard/server:public!>


### PR DESCRIPTION
## Summary

Adds a `wireguard` feature to the jumpbox kit, mirroring the existing `openvpn` feature, backed by the genesis-community wireguard BOSH release.

- New `wireguard` feature: colocates the wireguard, bpm, and networking-release iptables jobs on the jumpbox instance group (tunnel default 10.20.31.0/24, UDP 51820)
- Server keypair ensured idempotently in vault by the blueprint hook (Curve25519 via `wg genkey`, openssl X25519 fallback); vault refs only — no key material in manifests
- Peer lifecycle addons: `add-peer`, `remove-peer`, `list-peers`, `generate-wg-config` (with `-q` QR output), plus `smoke`; peers live in a vault registry and render into the manifest at build time, applied via `wg syncconf` so established tunnels survive redeploys
- openvpn + wireguard coexistence: when both features are active, a combined iptables overlay merges the FORWARD rules and both MASQUERADEs (distinct client pools: 172.31.255.0/24 openvpn, 10.20.31.0/24 wireguard)
- `genesis new` prompts for CIDR, routed networks, DNS, and endpoint
- Spec fixtures for wireguard, wireguard-all-params, and combined openvpn-wireguard; MANUAL.md docs; ci upstream entries for wireguard and bpm
- Fixes addon usage strings kit-wide to the canonical `genesis <env> do <addon>` syntax

Requires ubuntu-noble stemcells (in-kernel wireguard module).

## Testing

- Spec suite green (`cd spec && go test ./...`)
- Deployed on a pve lab via the mgmt director: wireguard-only deploy verified with a live peer handshake from the bastion; combined openvpn+wireguard deploy verified live (both processes running, merged iptables chains on the wire, tunnel survived redeploy)